### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Bot_IR          KEYWORD1
+Bot_IR	KEYWORD1
 Bot_Motor		KEYWORD1
 
 #######################################
@@ -14,21 +14,21 @@ Bot_Motor		KEYWORD1
 #######################################
 
 # for BOT_IR
-setup           KEYWORD2
-txFrequency     KEYWORD2
-txDataPin       KEYWORD2
-rxBusy          KEYWORD2
-rxDataReady     KEYWORD2
-rxData          KEYWORD2
-irRxIntEnable   KEYWORD2
-irRxIntDisable  KEYWORD2
-txData          KEYWORD2
-txInit          KEYWORD2
-irTxIntEnable   KEYWORD2
-irTxIntDisable  KEYWORD2
-txPing          KEYWORD2
-rxPing          KEYWORD2
-ping            KEYWORD2
+setup	KEYWORD2
+txFrequency	KEYWORD2
+txDataPin	KEYWORD2
+rxBusy	KEYWORD2
+rxDataReady	KEYWORD2
+rxData	KEYWORD2
+irRxIntEnable	KEYWORD2
+irRxIntDisable	KEYWORD2
+txData	KEYWORD2
+txInit	KEYWORD2
+irTxIntEnable	KEYWORD2
+irTxIntDisable	KEYWORD2
+txPing	KEYWORD2
+rxPing	KEYWORD2
+ping	KEYWORD2
 
 # for Bot_Motor
 motor 			KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords